### PR TITLE
Resolve unrecognized secrets named-value

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      SONAR_ORG: ${{ secrets.SONAR_ORG }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -25,14 +29,14 @@ jobs:
       - name: Test
         run: pytest -m "not e2e and not integration" --cov=swe_ai_fleet --cov-report=xml
       - name: SonarCloud Scan
-        if: ${{ secrets.SONAR_TOKEN != '' && secrets.SONAR_ORG != '' }}
+        if: ${{ env.SONAR_TOKEN != '' && env.SONAR_ORG != '' }}
         uses: sonarsource/sonarcloud-github-action@v2
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
         with:
           args: >
-            -Dsonar.organization=${{ secrets.SONAR_ORG }}
+            -Dsonar.organization=${{ env.SONAR_ORG }}
   integration:
     if: false  # Disabled for now; placeholder for future implementation
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes "Unrecognized named-value: 'secrets'" error in GitHub Actions workflow by mapping `secrets` to job-level `env` variables and referencing `env` in `if` conditions and `with.args`.

## Type

- [ ] chore(hardening)
- [x] fix
- [ ] feat
- [ ] docs

## Tests

- [ ] Unit tests added/updated
- [x] CI green (expected after this fix)

## Notes

GitHub Actions' `secrets` context is not available in all expression locations (e.g., `if` conditions, `with.args` for some actions). Using `env` as an intermediary resolves this.

---
<a href="https://cursor.com/background-agent?bcId=bc-11a2315c-6579-434e-aea6-b9676bc2d3d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-11a2315c-6579-434e-aea6-b9676bc2d3d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

