### PR TITLE
Add decision report generation and Neo4j integration

### DIFF
--- a/src/swe_ai_fleet/reports/adapters/neo4j_decision_graph_read_adapter.py
+++ b/src/swe_ai_fleet/reports/adapters/neo4j_decision_graph_read_adapter.py
@@ -1,0 +1,123 @@
+from swe_ai_fleet.memory.neo4j_store import Neo4jStore
+from swe_ai_fleet.reports.domain.decision_edges import DecisionEdges
+from swe_ai_fleet.reports.domain.decision_node import DecisionNode
+from swe_ai_fleet.reports.domain.subtask_node import SubtaskNode
+from swe_ai_fleet.reports.dtos.dtos import PlanVersionDTO
+from swe_ai_fleet.reports.ports.decision_graph_read_port import (
+    DecisionGraphReadPort,
+)
+
+
+class Neo4jDecisionGraphReadAdapter(DecisionGraphReadPort):
+    """
+    Read-only adapter using a thin `Neo4jStore` wrapper.
+    Assumes the knowledge graph already projected:
+      (:Case {id})-[:HAS_PLAN]->(:PlanVersion {id, version, status})
+      (:PlanVersion)-[:CONTAINS_DECISION]->(:Decision {
+        id, title, rationale, status, created_at_ms, author_id?
+      })
+      (:Decision)-[:AUTHORED_BY]->(:Actor {id})
+      (:Subtask)-[:INFLUENCED_BY]->(:Decision)
+      (Decision)-[REL]->(Decision)
+      with types like DEPENDS_ON, GOVERNS, etc.
+    """
+
+    def __init__(self, store: Neo4jStore) -> None:
+        self._store = store
+
+    def close(self) -> None:
+        # The store API does not expose close semantics; no-op for symmetry.
+        return None
+
+    def get_plan_by_case(self, case_id: str) -> PlanVersionDTO | None:
+        q = (
+            "MATCH (c:Case {id:$cid})-[:HAS_PLAN]->(p:PlanVersion)\n"
+            "RETURN p.id AS plan_id, p.case_id AS case_id,\n"
+            "       p.version AS version, p.status AS status,\n"
+            "       p.author_id AS author_id, p.rationale AS rationale,\n"
+            "       p.created_at_ms AS created_at_ms\n"
+            "ORDER BY coalesce(p.version,0) DESC\n"
+            "LIMIT 1"
+        )
+        recs = self._store.query(q, {"cid": case_id})
+        if not recs:
+            return None
+        rec = recs[0]
+        return PlanVersionDTO(
+            plan_id=rec["plan_id"],
+            case_id=rec.get("case_id") or case_id,
+            version=int(rec.get("version") or 0),
+            status=str(rec.get("status") or "UNKNOWN"),
+            author_id=str(rec.get("author_id") or "unknown"),
+            rationale=str(rec.get("rationale") or ""),
+            subtasks=[],  # not needed here; impacts are queried separately
+            created_at_ms=int(rec.get("created_at_ms") or 0),
+        )
+
+    def list_decisions(self, case_id: str) -> list[DecisionNode]:
+        q = (
+            "MATCH (c:Case {id:$cid})-[:HAS_PLAN]->(:PlanVersion)\n"
+            "-[:CONTAINS_DECISION]->(d:Decision)\n"
+            "OPTIONAL MATCH (d)-[:AUTHORED_BY]->(a:Actor)\n"
+            "RETURN d.id AS id, d.title AS title, d.rationale AS rationale,\n"
+            "       d.status AS status,\n"
+            "       coalesce(d.created_at_ms,0) AS created_at_ms,\n"
+            "       coalesce(d.author_id, a.id, 'unknown') AS author_id\n"
+            "ORDER BY created_at_ms ASC, id ASC"
+        )
+        return [
+            DecisionNode(
+                id=str(r["id"]),
+                title=str(r.get("title") or ""),
+                rationale=str(r.get("rationale") or ""),
+                status=str(r.get("status") or "PROPOSED"),
+                created_at_ms=int(r.get("created_at_ms") or 0),
+                author_id=str(r.get("author_id") or "unknown"),
+            )
+            for r in self._store.query(q, {"cid": case_id})
+        ]
+
+    def list_decision_dependencies(self, case_id: str) -> list[DecisionEdges]:
+        q = (
+            "MATCH (c:Case {id:$cid})-[:HAS_PLAN]->(:PlanVersion)\n"
+            "-[:CONTAINS_DECISION]->(d1:Decision)\n"
+            "MATCH (d1)-[r]->(d2:Decision)\n"
+            "WHERE type(r) IS NOT NULL\n"
+            "RETURN d1.id AS src,\n"
+            "       type(r) AS rel,\n"
+            "       d2.id AS dst"
+        )
+        return [
+            DecisionEdges(
+                src_id=str(r["src"]),
+                rel_type=str(r["rel"]),
+                dst_id=str(r["dst"]),
+            )
+            for r in self._store.query(q, {"cid": case_id})
+        ]
+
+    type SubtaskImpact = tuple[str, SubtaskNode]
+
+    def list_decision_impacts(self, case_id: str) -> list[SubtaskImpact]:
+        q = (
+            "MATCH (c:Case {id:$cid})-[:HAS_PLAN]->(:PlanVersion)\n"
+            "-[:CONTAINS_DECISION]->(d:Decision)\n"
+            "MATCH (s:Subtask)-[:INFLUENCED_BY]->(d)\n"
+            "RETURN d.id AS did, s.id AS sid,\n"
+            "       s.title AS stitle,\n"
+            "       s.role AS srole\n"
+            "ORDER BY did, sid"
+        )
+        out: list[tuple[str, SubtaskNode]] = []
+        for r in self._store.query(q, {"cid": case_id}):
+            out.append(
+                (
+                    str(r["did"]),
+                    SubtaskNode(
+                        id=str(r["sid"]),
+                        title=str(r.get("stitle") or ""),
+                        role=str(r.get("srole") or ""),
+                    ),
+                )
+            )
+        return out

--- a/src/swe_ai_fleet/reports/decision_enriched_report.py
+++ b/src/swe_ai_fleet/reports/decision_enriched_report.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from swe_ai_fleet.reports.adapters.redis_planning_read_adapter import (
+    RedisPlanningReadAdapter,
+)
+from swe_ai_fleet.reports.domain.decision_edges import DecisionEdges
+from swe_ai_fleet.reports.domain.decision_enriched_report import (
+    DecisionEnrichedReport,
+)
+from swe_ai_fleet.reports.domain.decision_node import DecisionNode
+from swe_ai_fleet.reports.domain.report import Report
+from swe_ai_fleet.reports.domain.report_request import ReportRequest
+from swe_ai_fleet.reports.domain.subtask_node import SubtaskNode
+from swe_ai_fleet.reports.dtos.dtos import (
+    CaseSpecDTO,
+    PlanningEventDTO,
+    PlanVersionDTO,
+)
+from swe_ai_fleet.reports.ports.decision_graph_read_port import (
+    DecisionGraphReadPort,
+)
+
+
+class DecisionEnrichedReportUseCase:
+    """
+    Generates a Markdown report guided by the decision graph (Neo4j),
+    and enriched with planning milestones (Redis).
+    """
+
+    def __init__(
+        self,
+        redis_store: RedisPlanningReadAdapter,
+        graph_store: DecisionGraphReadPort,
+    ) -> None:
+        self.redis = redis_store
+        self.graph = graph_store
+
+    def generate(self, req: ReportRequest) -> DecisionEnrichedReport:
+        spec = self.redis.get_case_spec(req.case_id)
+        if not spec:
+            raise ValueError("Case spec not found.")
+
+        # Graph-driven core
+        plan_g = self.graph.get_plan_by_case(req.case_id)
+        decisions = self.graph.list_decisions(req.case_id)
+        dep_edges = self.graph.list_decision_dependencies(req.case_id)
+        impacts = self.graph.list_decision_impacts(req.case_id)
+
+        # Redis-driven milestones / timeline
+        events = (
+            self.redis.get_planning_events(req.case_id, count=req.max_events)
+            if req.include_timeline
+            else []
+        )
+        plan_r = self.redis.get_plan_draft(
+            req.case_id
+        )  # to get subtasks table if you want to display it
+
+        md = self._render_markdown(
+            spec,
+            plan_g or plan_r,
+            decisions,
+            dep_edges,
+            impacts,
+            events,
+            req,
+        )
+        stats = self._compute_stats(decisions, dep_edges, impacts, plan_g or plan_r, events)
+        report = DecisionEnrichedReport(
+            case_id=spec.case_id,
+            plan_id=(plan_g.plan_id if plan_g else (plan_r.plan_id if plan_r else None)),
+            generated_at_ms=int(time.time() * 1000),
+            markdown=md,
+            stats=stats,
+        )
+
+        if req.persist_to_redis:
+            # re-use implementation report storage keys to avoid proliferation
+            ir = Report(
+                case_id=report.case_id,
+                plan_id=report.plan_id,
+                generated_at_ms=report.generated_at_ms,
+                markdown=report.markdown,
+                stats=report.stats,
+            )
+            self.redis.save_report(spec.case_id, ir, req.ttl_seconds)
+
+        return report
+
+    # ---- helpers ----
+
+    @staticmethod
+    def _compute_stats(
+        decisions: list[DecisionNode],
+        dep_edges: list[DecisionEdges],
+        impacts: list[tuple[str, SubtaskNode]],
+        plan: PlanVersionDTO | None,
+        events: list[PlanningEventDTO],
+    ) -> dict[str, Any]:
+        deps_per_decision: dict[str, int] = {}
+        for e in dep_edges:
+            deps_per_decision[e.src_id] = deps_per_decision.get(e.src_id, 0) + 1
+        impact_counts: dict[str, int] = {}
+        for did, _ in impacts:
+            impact_counts[did] = impact_counts.get(did, 0) + 1
+        return {
+            "decisions": len(decisions),
+            "decision_edges": len(dep_edges),
+            "impacted_subtasks": len(impacts),
+            "plan_status": (plan.status if plan else "UNKNOWN"),
+            "events": len(events),
+            "max_dependencies_on_one_decision": (
+                max(deps_per_decision.values()) if deps_per_decision else 0
+            ),
+            "max_impacts_from_one_decision": (max(impact_counts.values()) if impact_counts else 0),
+        }
+
+    def _render_markdown(
+        self,
+        spec: CaseSpecDTO,
+        plan: PlanVersionDTO | None,
+        decisions: list[DecisionNode],
+        dep_edges: list[DecisionEdges],
+        impacts: list[tuple[str, SubtaskNode]],
+        events: list[PlanningEventDTO],
+        req: ReportRequest,
+    ) -> str:
+        def fmt_ts(ms: int) -> str:
+            if not ms:
+                return "-"
+            return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(ms / 1000))
+
+        lines: list[str] = []
+        lines.append(f"# Implementation Report (Graph-guided) — {spec.title}\n")
+        lines.append(f"- **Case ID:** `{spec.case_id}`")
+        if plan:
+            lines.append(
+                f"- **Plan ID:** `{plan.plan_id}`  |  **Status:** "
+                f"`{plan.status}`  |  **Version:** `{plan.version}`"
+            )
+        lines.append(f"- **Generated at:** `{time.strftime('%Y-%m-%d %H:%M:%S')}`\n")
+
+        lines.append("## Overview")
+        lines.append(spec.description or "_No description provided._")
+        if req.include_constraints and spec.constraints:
+            lines.append("\n### Constraints")
+            for k, v in spec.constraints.items():
+                lines.append(f"- **{k}:** {v}")
+        if spec.acceptance_criteria and req.include_acceptance:
+            lines.append("\n### Acceptance Criteria")
+            for i, ac in enumerate(spec.acceptance_criteria, start=1):
+                lines.append(f"{i}. {ac}")
+
+        # ----- Graph: Decisions -----
+        lines.append("\n## Decisions (ordered)")
+        if not decisions:
+            lines.append("_No decisions projected in graph._")
+        else:
+            lines.append("| ID | Title | Status | Author | Created At |")
+            lines.append("|---|---|---|---|---|")
+            for d in decisions:
+                lines.append(
+                    f"| `{d.id}` | {d.title} | `{d.status}` | "
+                    f"`{d.author_id}` | {fmt_ts(d.created_at_ms)} |"
+                )
+
+        # ----- Graph: Dependencies between decisions -----
+        lines.append("\n## Decision Dependency Map")
+        if not dep_edges:
+            lines.append("_No dependencies between decisions._")
+        else:
+            # adjacency-like compact view
+            by_src: dict[str, list[DecisionEdges]] = {}
+            for e in dep_edges:
+                by_src.setdefault(e.src_id, []).append(e)
+            for src, edges in by_src.items():
+                rhs = ", ".join(f"`{e.rel_type}` → `{e.dst_id}`" for e in edges)
+                lines.append(f"- `{src}`: {rhs}")
+
+        # ----- Graph: Impacts on Subtasks -----
+        lines.append("\n## Decision → Subtask Impact")
+        if not impacts:
+            lines.append("_No subtask influenced by decisions._")
+        else:
+            lines.append("| Decision | Subtask | Role |")
+            lines.append("|---|---|---|")
+            for did, s in impacts:
+                lines.append(f"| `{did}` | `{s.id}`: {s.title} | `{s.role}` |")
+
+        # ----- (Optional) Subtasks table from Redis draft -----
+        if plan and req.include_dependencies:
+            # Try to enrich from Redis draft subtasks if available
+            draft = self.redis.get_plan_draft(spec.case_id)
+            if draft and draft.subtasks:
+                lines.append("\n## Subtasks (from planning draft)")
+                lines.append(
+                    "| ID | Title | Role | Depends On | Est. Points | Priority | Risk | Tech |"
+                )
+                lines.append("|---|---|---|---|---:|---:|---:|---|")
+                for st in draft.subtasks:
+                    deps = ", ".join(st.depends_on) if st.depends_on else "-"
+                    tech = ", ".join(st.suggested_tech) if st.suggested_tech else "-"
+                    lines.append(
+                        f"| `{st.subtask_id}` | {st.title} | `{st.role}` | {deps} | "
+                        f"{st.estimate_points:.1f} | {st.priority} | {st.risk_score:.2f} | {tech} |"
+                    )
+
+        # ----- Milestones (PO-led) from Redis planning events -----
+        if req.include_timeline and events:
+            lines.append("\n## Milestones & Timeline (PO-led)")
+            # Extract key milestones
+            milestones: list[str] = []
+            for ev in events:
+                ts = fmt_ts(ev.ts_ms)
+                if ev.event == "create_case_spec":
+                    milestones.append(f"- `{ts}` — **Case created** by `{ev.actor}`")
+                elif ev.event == "propose_plan":
+                    milestones.append(f"- `{ts}` — **Plan proposed** by `{ev.actor}`")
+                elif ev.event == "human_edit":
+                    milestones.append(f"- `{ts}` — **Human edits** by `{ev.actor}`")
+                elif ev.event == "approve_plan":
+                    milestones.append(f"- `{ts}` — **Plan approved** by `{ev.actor}` ✅")
+            if plan:
+                milestones.append(f"- **Current plan status:** `{plan.status}` (v{plan.version})")
+            lines.extend(milestones or ["_No milestones found._"])
+
+        # ----- Next steps -----
+        lines.append("\n## Next Steps")
+        lines.append("- Validate decision dependencies vs. implementation order.")
+        lines.append("- Ensure observability and security decisions are reflected in CI/CD.")
+        lines.append("- Reconcile plan status with PO priorities and delivery timeline.")
+        lines.append("")
+        return "\n".join(lines)

--- a/src/swe_ai_fleet/reports/domain/decision_edges.py
+++ b/src/swe_ai_fleet/reports/domain/decision_edges.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DecisionEdges:
+    src_id: str
+    rel_type: str
+    dst_id: str

--- a/src/swe_ai_fleet/reports/domain/decision_enriched_report.py
+++ b/src/swe_ai_fleet/reports/domain/decision_enriched_report.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class DecisionEnrichedReport:
+    case_id: str
+    plan_id: str | None
+    generated_at_ms: int
+    markdown: str
+    stats: dict[str, Any] = field(default_factory=dict)

--- a/src/swe_ai_fleet/reports/domain/decision_node.py
+++ b/src/swe_ai_fleet/reports/domain/decision_node.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DecisionNode:
+    id: str
+    title: str
+    rationale: str
+    status: str
+    created_at_ms: int
+    author_id: str

--- a/src/swe_ai_fleet/reports/domain/subtask_node.py
+++ b/src/swe_ai_fleet/reports/domain/subtask_node.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SubtaskNode:
+    id: str
+    title: str
+    role: str

--- a/src/swe_ai_fleet/reports/ports/decision_graph_read_port.py
+++ b/src/swe_ai_fleet/reports/ports/decision_graph_read_port.py
@@ -1,0 +1,13 @@
+from typing import Protocol
+
+from swe_ai_fleet.reports.domain.decision_edges import DecisionEdges
+from swe_ai_fleet.reports.domain.decision_node import DecisionNode
+from swe_ai_fleet.reports.domain.subtask_node import SubtaskNode
+from swe_ai_fleet.reports.dtos.dtos import PlanVersionDTO
+
+
+class DecisionGraphReadPort(Protocol):
+    def get_plan_by_case(self, case_id: str) -> PlanVersionDTO | None: ...
+    def list_decisions(self, case_id: str) -> list[DecisionNode]: ...
+    def list_decision_dependencies(self, case_id: str) -> list[DecisionEdges]: ...
+    def list_decision_impacts(self, case_id: str) -> list[tuple[str, SubtaskNode]]: ...

--- a/tests/e2e/test_decision_enriched_report_e2e.py
+++ b/tests/e2e/test_decision_enriched_report_e2e.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+import pytest
+import redis
+
+from swe_ai_fleet.reports.adapters.redis_planning_read_adapter import (
+    RedisPlanningReadAdapter,
+)
+from swe_ai_fleet.reports.decision_enriched_report import (
+    DecisionEnrichedReportUseCase,
+)
+from swe_ai_fleet.reports.domain.decision_edges import DecisionEdges
+from swe_ai_fleet.reports.domain.decision_node import DecisionNode
+from swe_ai_fleet.reports.domain.report_request import ReportRequest
+from swe_ai_fleet.reports.domain.subtask_node import SubtaskNode
+from swe_ai_fleet.reports.dtos.dtos import PlanVersionDTO
+from swe_ai_fleet.reports.ports.decision_graph_read_port import (
+    DecisionGraphReadPort,
+)
+
+pytestmark = pytest.mark.e2e
+
+
+def _k_spec(case_id: str) -> str:
+    return f"swe:case:{case_id}:spec"
+
+
+def _k_draft(case_id: str) -> str:
+    return f"swe:case:{case_id}:planning:draft"
+
+
+def _k_stream(case_id: str) -> str:
+    return f"swe:case:{case_id}:planning:stream"
+
+
+def _k_report_list(case_id: str) -> str:
+    return f"swe:case:{case_id}:reports:implementation:ids"
+
+
+def _k_report_doc(case_id: str, report_id: str) -> str:
+    return f"swe:case:{case_id}:reports:implementation:{report_id}"
+
+
+def _k_report_last(case_id: str) -> str:
+    return f"swe:case:{case_id}:reports:implementation:last"
+
+
+def _cleanup_case(r: redis.Redis, case_id: str) -> None:
+    # best-effort cleanup
+    keys = [
+        _k_spec(case_id),
+        _k_draft(case_id),
+        _k_stream(case_id),
+        _k_report_list(case_id),
+        _k_report_last(case_id),
+    ]
+    r.delete(*keys)
+
+
+class _FakeGraphAdapter(DecisionGraphReadPort):
+    def __init__(
+        self,
+        plan: PlanVersionDTO | None,
+        decisions: list[DecisionNode],
+        deps: list[DecisionEdges],
+        impacts: list[tuple[str, SubtaskNode]],
+    ) -> None:
+        self._plan = plan
+        self._decisions = decisions
+        self._deps = deps
+        self._impacts = impacts
+
+    def get_plan_by_case(self, case_id: str) -> PlanVersionDTO | None:
+        return self._plan
+
+    def list_decisions(self, case_id: str) -> list[DecisionNode]:
+        return self._decisions
+
+    def list_decision_dependencies(self, case_id: str) -> list[DecisionEdges]:
+        return self._deps
+
+    def list_decision_impacts(self, case_id: str) -> list[tuple[str, SubtaskNode]]:
+        return self._impacts
+
+
+def test_decision_enriched_report_e2e_end_to_end() -> None:
+    url = "redis://:swefleet-dev@localhost:6379/0"
+    r: redis.Redis = redis.Redis.from_url(url, decode_responses=True)
+
+    case_id = f"e2e-decision-enriched-{int(time.time())}"
+    _cleanup_case(r, case_id)
+
+    # Seed case spec
+    spec_doc: dict[str, Any] = {
+        "case_id": case_id,
+        "title": "E2E Decision-Enriched",
+        "description": "End-to-end decision-enriched report",
+        "acceptance_criteria": ["renders"],
+        "constraints": {"env": "prod"},
+        "requester_id": "user-1",
+        "tags": ["e2e"],
+        "created_at_ms": int(time.time() * 1000),
+    }
+    r.set(_k_spec(case_id), json.dumps(spec_doc))
+
+    # Seed plan draft with one subtask (used for optional subtasks table)
+    draft_doc: dict[str, Any] = {
+        "plan_id": "P1",
+        "case_id": case_id,
+        "version": 2,
+        "status": "draft",
+        "author_id": "bot",
+        "rationale": "because",
+        "created_at_ms": int(time.time() * 1000),
+        "subtasks": [
+            {
+                "subtask_id": "S1",
+                "title": "Implement",
+                "description": "Do it",
+                "role": "dev",
+                "suggested_tech": ["python"],
+                "depends_on": [],
+                "estimate_points": 3.0,
+                "priority": 1,
+                "risk_score": 0.2,
+                "notes": "",
+            }
+        ],
+    }
+    r.set(_k_draft(case_id), json.dumps(draft_doc))
+
+    # Seed planning events (newest-first stored by xrevrange; we add in order)
+    r.xadd(
+        _k_stream(case_id),
+        {"event": "create_case_spec", "actor": "user", "payload": "{}", "ts": "1"},
+    )
+    r.xadd(
+        _k_stream(case_id),
+        {"event": "propose_plan", "actor": "bot", "payload": "{}", "ts": "2"},
+    )
+
+    # Build fake graph adapter data
+    plan = PlanVersionDTO(
+        plan_id="P1",
+        case_id=case_id,
+        version=2,
+        status="draft",
+        author_id="bot",
+    )
+    decisions = [
+        DecisionNode(
+            id="D1",
+            title="Choose DB",
+            rationale="Postgres is fine",
+            status="accepted",
+            created_at_ms=int(time.time() * 1000),
+            author_id="arch",
+        )
+    ]
+    deps = [DecisionEdges(src_id="D1", rel_type="GOVERNS", dst_id="D2")]
+    impacts = [("D1", SubtaskNode(id="S1", title="Implement", role="dev"))]
+
+    # Build use case with Redis-backed adapter and fake graph adapter
+    # Minimal KV port shim over redis-py client
+    class _KvShim:
+        def __init__(self, client: redis.Redis):
+            self._c = client
+
+        def get(self, key: str) -> str | None:
+            return self._c.get(key)
+
+        def xrevrange(self, key: str, count: int | None = None):
+            return self._c.xrevrange(key, count=count)
+
+        def pipeline(self):
+            return self._c.pipeline()
+
+    redis_adapter = RedisPlanningReadAdapter(_KvShim(r))
+    graph_adapter = _FakeGraphAdapter(plan, decisions, deps, impacts)
+    usecase = DecisionEnrichedReportUseCase(redis_adapter, graph_adapter)
+
+    req = ReportRequest(
+        case_id=case_id,
+        include_constraints=True,
+        include_acceptance=True,
+        include_timeline=True,
+        include_dependencies=True,
+        persist_to_redis=True,
+        ttl_seconds=120,
+    )
+
+    report = usecase.generate(req)
+
+    # Validate persistence
+    last_id = r.get(_k_report_last(case_id))
+    assert last_id is not None
+    doc_raw = r.get(_k_report_doc(case_id, str(last_id)))
+    assert doc_raw is not None
+    doc = json.loads(doc_raw)
+    assert doc["case_id"] == case_id
+
+    # Validate content and stats look correct
+    assert "Implementation Report (Graph-guided)" in report.markdown
+    assert f"`{case_id}`" in report.markdown
+    assert "## Decisions (ordered)" in report.markdown
+    assert "## Decision Dependency Map" in report.markdown
+    assert "## Decision → Subtask Impact" in report.markdown
+    assert report.plan_id == "P1"
+    assert report.stats["decisions"] == len(decisions)
+    assert report.stats["decision_edges"] == len(deps)
+    assert report.stats["impacted_subtasks"] == len(impacts)
+    assert report.stats["plan_status"] == plan.status

--- a/tests/unit/test_neo4j_decision_graph_read_adapter_unit.py
+++ b/tests/unit/test_neo4j_decision_graph_read_adapter_unit.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+# Ensure adapter import works without the real 'neo4j' package
+if "neo4j" not in sys.modules:
+    fake_neo4j = types.ModuleType("neo4j")
+
+    class _FakeGraphDatabase:
+        @staticmethod
+        def driver(*_args, **_kwargs):
+            return None
+
+    fake_neo4j.GraphDatabase = _FakeGraphDatabase
+    sys.modules["neo4j"] = fake_neo4j
+
+from swe_ai_fleet.reports.adapters.neo4j_decision_graph_read_adapter import (
+    Neo4jDecisionGraphReadAdapter,
+)
+from swe_ai_fleet.reports.domain.decision_edges import DecisionEdges
+from swe_ai_fleet.reports.domain.decision_node import DecisionNode
+from swe_ai_fleet.reports.domain.subtask_node import SubtaskNode
+from swe_ai_fleet.reports.dtos.dtos import PlanVersionDTO
+
+
+class _FakeStore:
+    def __init__(self, results_by_query: dict[str, list[dict[str, Any]]]):
+        self._results_by_query = results_by_query
+
+    def query(self, cypher: str, params: dict[str, Any]) -> list[dict[str, Any]]:
+        if "RETURN p.id AS plan_id" in cypher:
+            return self._results_by_query.get("plan", [])
+        if "RETURN d.id AS id" in cypher:
+            return self._results_by_query.get("decisions", [])
+        if "RETURN d1.id AS src" in cypher:
+            return self._results_by_query.get("deps", [])
+        if "RETURN d.id AS did" in cypher:
+            return self._results_by_query.get("impacts", [])
+        return []
+
+
+def _make_adapter_with_fake(  # type: ignore[no-untyped-def]
+    results_by_query: dict[str, list[dict[str, Any]]],
+) -> Neo4jDecisionGraphReadAdapter:
+    store = _FakeStore(results_by_query)
+    return Neo4jDecisionGraphReadAdapter(store)
+
+
+def test_get_plan_by_case_none():
+    adapter = _make_adapter_with_fake({"plan": [], "decisions": [], "deps": [], "impacts": []})
+    assert adapter.get_plan_by_case("C1") is None
+
+
+def test_get_plan_by_case_maps_fields_and_defaults():
+    adapter = _make_adapter_with_fake(
+        {
+            "plan": [
+                {
+                    "plan_id": "P1",
+                    "case_id": None,
+                    "version": "2",
+                    "status": None,
+                    "author_id": None,
+                    "rationale": None,
+                    "created_at_ms": "100",
+                }
+            ]
+        },
+    )
+
+    pv = adapter.get_plan_by_case("C1")
+    assert isinstance(pv, PlanVersionDTO)
+    assert pv and pv.plan_id == "P1"
+    assert pv.case_id == "C1"  # fallback to requested case_id
+    assert pv.version == 2
+    assert pv.status == "UNKNOWN"
+    assert pv.author_id == "unknown"
+    assert pv.rationale == ""
+    assert pv.subtasks == []
+    assert pv.created_at_ms == 100
+
+
+def test_list_decisions_maps_records_and_defaults():
+    adapter = _make_adapter_with_fake(
+        {
+            "decisions": [
+                {
+                    "id": "D1",
+                    "title": "T1",
+                    "rationale": "R",
+                    "status": "accepted",
+                    "created_at_ms": 10,
+                    "author_id": "U1",
+                },
+                {
+                    "id": "D2",
+                    # title missing -> ""
+                    "rationale": "",
+                    # status missing -> PROPOSED
+                    "created_at_ms": None,  # -> 0
+                    # author_id missing -> unknown
+                },
+            ]
+        },
+    )
+
+    out = adapter.list_decisions("C1")
+    assert out == [
+        DecisionNode(
+            id="D1",
+            title="T1",
+            rationale="R",
+            status="accepted",
+            created_at_ms=10,
+            author_id="U1",
+        ),
+        DecisionNode(
+            id="D2",
+            title="",
+            rationale="",
+            status="PROPOSED",
+            created_at_ms=0,
+            author_id="unknown",
+        ),
+    ]
+
+
+def test_list_decision_dependencies_maps_edges():
+    adapter = _make_adapter_with_fake({"deps": [{"src": "D1", "rel": "DEPENDS_ON", "dst": "D2"}]})
+    out = adapter.list_decision_dependencies("C1")
+    assert out == [DecisionEdges(src_id="D1", rel_type="DEPENDS_ON", dst_id="D2")]
+
+
+def test_list_decision_impacts_maps_subtasks():
+    adapter = _make_adapter_with_fake(
+        {
+            "impacts": [
+                {"did": "D1", "sid": "S1", "stitle": "Sub1", "srole": "dev"},
+                {"did": "D1", "sid": "S2", "stitle": None, "srole": None},
+            ]
+        },
+    )
+
+    out = adapter.list_decision_impacts("C1")
+    assert out == [
+        ("D1", SubtaskNode(id="S1", title="Sub1", role="dev")),
+        ("D1", SubtaskNode(id="S2", title="", role="")),
+    ]
+
+
+def test_close_noop():
+    adapter = _make_adapter_with_fake({})
+    assert adapter.close() is None

--- a/tests/unit/test_reports_decision_domain_unit.py
+++ b/tests/unit/test_reports_decision_domain_unit.py
@@ -1,0 +1,102 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from swe_ai_fleet.reports.domain.decision_edges import DecisionEdges
+from swe_ai_fleet.reports.domain.decision_enriched_report import (
+    DecisionEnrichedReport,
+)
+from swe_ai_fleet.reports.domain.decision_node import DecisionNode
+from swe_ai_fleet.reports.domain.subtask_node import SubtaskNode
+
+
+def test_decisionedges_basic_and_frozen():
+    edge1 = DecisionEdges(src_id="N1", rel_type="DEPENDS_ON", dst_id="N2")
+    edge2 = DecisionEdges(src_id="N1", rel_type="DEPENDS_ON", dst_id="N2")
+
+    assert edge1 == edge2
+    assert isinstance(hash(edge1), int)
+
+    with pytest.raises(FrozenInstanceError):
+        edge1.rel_type = "CAUSES"
+
+
+def test_decisionnode_basic_and_frozen():
+    node1 = DecisionNode(
+        id="D1",
+        title="Choose approach",
+        rationale="Faster to implement",
+        status="accepted",
+        created_at_ms=123456,
+        author_id="U1",
+    )
+    node2 = DecisionNode(
+        id="D1",
+        title="Choose approach",
+        rationale="Faster to implement",
+        status="accepted",
+        created_at_ms=123456,
+        author_id="U1",
+    )
+
+    assert node1 == node2
+    assert isinstance(hash(node1), int)
+
+    with pytest.raises(FrozenInstanceError):
+        node1.title = "New title"
+
+
+def test_subtasknode_basic_and_frozen():
+    st1 = SubtaskNode(id="S1", title="Implement X", role="dev")
+    st2 = SubtaskNode(id="S1", title="Implement X", role="dev")
+
+    assert st1 == st2
+    assert isinstance(hash(st1), int)
+
+    with pytest.raises(FrozenInstanceError):
+        st1.role = "qa"
+
+
+def test_decisionenrichedreport_defaults_frozen_and_stats_independence():
+    rpt1 = DecisionEnrichedReport(
+        case_id="C1",
+        plan_id=None,
+        generated_at_ms=1,
+        markdown="# Report\n",
+    )
+    rpt2 = DecisionEnrichedReport(
+        case_id="C2",
+        plan_id=None,
+        generated_at_ms=2,
+        markdown="# Report\n",
+    )
+
+    assert rpt1.stats == {}
+    assert rpt2.stats == {}
+    assert rpt1.stats is not rpt2.stats
+
+    rpt1.stats["k"] = "v"
+    assert rpt2.stats == {}
+
+    with pytest.raises(FrozenInstanceError):
+        rpt1.markdown = "updated"
+
+
+def test_decisionenrichedreport_equality_and_hashing_raises():
+    a = DecisionEnrichedReport(
+        case_id="C1",
+        plan_id="P1",
+        generated_at_ms=123,
+        markdown="m",
+    )
+    b = DecisionEnrichedReport(
+        case_id="C1",
+        plan_id="P1",
+        generated_at_ms=123,
+        markdown="m",
+    )
+
+    assert a == b
+
+    with pytest.raises(TypeError):
+        hash(a)


### PR DESCRIPTION
## Summary

- Introduced DecisionEnrichedReportUseCase for generating enriched reports based on decision graphs and planning milestones.
- Added Neo4jDecisionGraphReadAdapter for reading decision data from a Neo4j store.
- Created domain classes for decision nodes, edges, enriched reports, and subtasks.
- Implemented a new protocol for decision graph reading.
- Developed end-to-end and unit tests to validate report generation and data retrieval processes.

## Type

- [ ] chore(hardening)
- [ ] fix
- [ ] feat
- [ ] docs

## Tests

- [ ] Unit tests added/updated
- [ ] CI green

